### PR TITLE
Update PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,5 @@
-# Maintainer: Philip J. Repko <your@email.com>
-
 pkgname=sqlch-suite
-pkgver=3.4.1
+pkgver=1.1
 pkgrel=1
 pkgdesc="A modular internet radio CLI+GUI suite featuring a tray icon, TUI, and mpv controller"
 arch=('any')
@@ -9,26 +7,27 @@ url="https://github.com/SW-philip/sqlch-suite"
 license=('MIT')
 depends=('python' 'python-gobject' 'gtk3' 'libappindicator-gtk3' 'bash' 'hicolor-icon-theme' 'glib2')
 optdepends=('mpv: used by sqlchctl for playback')
-source=('sqlch'
-        'sqlchctl'
-        'sqlchknob'
-        'sqlchtray.py'
-        'sqlchtray.service'
-        'sqlchtray-icon.png'
-        'LICENSE')
-md5sums=('SKIP'
-         'SKIP'
-         'SKIP'
-         'SKIP'
-         'SKIP'
-         'SKIP'
-         'SKIP')
+
+source=("https://github.com/SW-philip/sqlch-suite/archive/refs/tags/v$pkgver.zip")
+sha256sums=('daf90d9f0252a6b8a1f885446f2ce513464ec8e3d90913f09a600424d4d27108')
+
+prepare() {
+  cd "$srcdir"
+  unzip "v$pkgver.zip"
+  mv "sqlch-suite-$pkgver" "$pkgname"
+}
+
+build() {
+  return 0
+}
 
 package() {
+  cd "$srcdir/$pkgname"
+
   install -Dm755 sqlch "$pkgdir/usr/bin/sqlch"
   install -Dm755 sqlchctl "$pkgdir/usr/bin/sqlchctl"
   install -Dm755 sqlchknob "$pkgdir/usr/bin/sqlchknob"
-  install -Dm755 sqlchtray.py "$pkgdir/usr/bin/sqlchtray"
+  install -Dm755 sqlchtray "$pkgdir/usr/bin/sqlchtray"
   install -Dm644 sqlchtray.service "$pkgdir/usr/lib/systemd/user/sqlchtray.service"
   install -Dm644 sqlchtray-icon.png "$pkgdir/usr/share/icons/hicolor/64x64/apps/sqlchtray-icon.png"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"


### PR DESCRIPTION
## Use Stable Releases and SHA256 Checksums

### What
- Updated the PKGBUILD to download stable releases from GitHub tags instead of using local source files.
- Switched checksum verification from MD5 to SHA256.

### Why
- **Stable Releases:** Using stable tagged releases ensures consistent, tested, and reliable source code versions, reducing unexpected breakages from development snapshots.
- **SHA256 Checksums:** SHA256 provides stronger cryptographic integrity verification than MD5, which is considered weak and vulnerable to collisions. This improves security and trust in the downloaded sources.
- **Improved Package Integrity:** These changes enhance the security and reproducibility of the package build process, following best practices in packaging and software distribution.
